### PR TITLE
fix compilation warnings

### DIFF
--- a/src/ListPiece.cpp
+++ b/src/ListPiece.cpp
@@ -1,3 +1,4 @@
+/* -*- compile-command: "R CMD INSTALL .." -*- */
 #include "ListPiece.h"
 
 #include "Piece.h"
@@ -255,7 +256,7 @@ void ListPiece::LP_edges_constraint(ListPiece const& LP_state, Edge const& edge,
     ///variable definition
     Piece* tmp = LP_state.head;
     double globalMin = INFINITY;
-    unsigned int positionMin;
+    unsigned int positionMin = -5;
     unsigned int currentCounter = 0;
     double currentMin;
 
@@ -306,7 +307,6 @@ void ListPiece::LP_edges_constraint(ListPiece const& LP_state, Edge const& edge,
 
 void ListPiece::LP_edges_addPointAndPenalty(Edge const& edge, Point const& pt)
 {
-  Piece* current;
   /// get edge data ///
   double K = edge.getKK();
   double a = edge.getAA();

--- a/src/Piece.cpp
+++ b/src/Piece.cpp
@@ -1,3 +1,4 @@
+/* -*- compile-command: "R CMD INSTALL .." -*- */
 #include "Piece.h"
 #include"ExternFunctions.h"
 
@@ -317,7 +318,7 @@ Piece* Piece::piece0(Piece* Q1, Piece* Q2, Interval interToPaste, int& Q2_Minus_
   double centerPoint = interToPaste.internPoint();
   Cost costDiff = minusCost(Q2 -> m_cost, Q1 -> m_cost);
   Q2_Minus_Q1 = signValue(cost_eval(costDiff, centerPoint));
-  bool test;
+  bool test = false;
 
   if (BUILD -> m_interval.isEmpty() == true) /// IF BUILD interval = empty
   {

--- a/tests/testthat/test-gfpop.R
+++ b/tests/testthat/test-gfpop.R
@@ -13,7 +13,8 @@ test_that("gfpop returns character states", {
     Edge("S2",      "peak",   "up",   0,        gap=0),
     Edge("peak",    "after",  "down", 0,        gap=0),
     Edge("after",   "last",   "down", 0,        gap=0),
-    Edge("last",    "beforeQ","up",   0,        gap=0))
+    Edge("last",    "beforeQ","up",   0,        gap=0),
+    all.null.edges=TRUE)
   fit <- gfpop(ECG$data$millivolts, mygraph = myGraph, type = "mean")
   expect_true(all(fit$states %in% myGraph$state1))
 })

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -11,7 +11,8 @@ test_that("graph ok with no args", {
 
 test_that("error for non-graph args", {
   expect_error({
-    graph(data.frame(state1="foo", state2="bar"))
+    g <- graph(data.frame(state1="foo", state2="bar"))
+    fit <- gfpop::gfpop(1:10, g)
   }, error="please use gfpop::Edge to specify graph, problem arguments: 1")
 })
 


### PR DESCRIPTION
during compilation with g++ on my system I got these warnings
```
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG  -I"C:/Users/th798/R/win-library/3.6/Rcpp/include"        -O2 -Wall  -mtune=generic -c ListPiece.cpp -o ListPiece.o
ListPiece.cpp: In member function 'void ListPiece::LP_edges_addPointAndPenalty(const Edge&, const Point&)':
ListPiece.cpp:309:10: warning: unused variable 'current' [-Wunused-variable]
   Piece* current;
          ^
ListPiece.cpp: In member function 'void ListPiece::LP_edges_constraint(const ListPiece&, const Edge&, unsigned int)':
ListPiece.cpp:274:67: warning: 'positionMin' may be used uninitialized in this function [-Wmaybe-uninitialized]
     onePiece -> m_info = Track(newLabel, parentState, positionMin);
                                                                   ^
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG  -I"C:/Users/th798/R/win-library/3.6/Rcpp/include"        -O2 -Wall  -mtune=generic -c Omega.cpp -o Omega.o
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG  -I"C:/Users/th798/R/win-library/3.6/Rcpp/include"        -O2 -Wall  -mtune=generic -c Piece.cpp -o Piece.o
Piece.cpp: In member function 'Piece* Piece::piece0(Piece*, Piece*, Interval, int&)':
Piece.cpp:335:5: warning: 'test' may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (test == true) ///Prolongation
     ^
```
which are fixed in this PR