### PR TITLE
Add GitHub Actions R-CMD-check CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@ build.sh
 ^.*\.Rproj$
 ^\.Rproj\.user$
 .travis.yml
+^\.github$
 figure
 gfpop_1.1.1.pdf
 tex

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,6 @@ name: R-CMD-check
 
 on:
   push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,40 @@
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::rcmdcheck
+            github::vrunge/gfpop.data
+          needs: check
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
+            any::remotes
             github::vrunge/gfpop.data
           needs: check
       - uses: r-lib/actions/check-r-package@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!--[![Build Status](http://travis-ci.com/vrunge/gfpop.svg?branch=master)](http://travis-ci.com/vrunge/gfpop)
 --> 
+[![R-CMD-check](https://github.com/vrunge/gfpop/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vrunge/gfpop/actions/workflows/R-CMD-check.yaml)
 [![](https://img.shields.io/badge/docs-vignettes-blue.svg)](https://github.com/vrunge/gfpop)
 
 <!-- 

--- a/tests/testthat/test-sn.R
+++ b/tests/testthat/test-sn.R
@@ -1,17 +1,22 @@
 library(gfpop)
-library(devtools)
-devtools::install_github("vrunge/gfpop.data")
-library(gfpop.data)
-
 library(testthat)
 context("sn")
 
-library(data.table)
+## The sn tests rely on the gfpop.data package (GitHub only:
+## vrunge/gfpop.data) and data.table. Skip gracefully when unavailable
+## instead of installing packages at test time.
+have.sn.deps <- requireNamespace("gfpop.data", quietly = TRUE) &&
+  requireNamespace("data.table", quietly = TRUE)
 
-data(profile614chr2, package="gfpop.data")
+if (have.sn.deps) {
+  library(gfpop.data)
+  library(data.table)
 
-### reduce data size
-profile614chr2$probes <- profile614chr2$probes[1:10000,]
+  data(profile614chr2, package = "gfpop.data")
+
+  ### reduce data size
+  profile614chr2$probes <- profile614chr2$probes[1:10000, ]
+}
 
 g <- gfpop::graph(type="std")
 x <- rnorm(10)
@@ -40,6 +45,7 @@ sngraph <- function(n.segs, type, gap)
 ######
 
 test_that("abs model with 1 segment returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g1 <- sngraph(1L, "abs", 1)
   fit1 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -50,6 +56,7 @@ test_that("abs model with 1 segment returned", {
 })
 
 test_that("abs model with 2 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g2 <- sngraph(2L, "abs", 1)
   fit2 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -61,6 +68,7 @@ test_that("abs model with 2 segments returned", {
 })
 
 test_that("abs model with 3 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g3 <- sngraph(3L, "abs", 1)
   fit3 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -76,6 +84,7 @@ test_that("abs model with 3 segments returned", {
 ######
 
 test_that("std model with 1 segment returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g1 <- sngraph(1L, "std", 0)
   fit1 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -86,6 +95,7 @@ test_that("std model with 1 segment returned", {
 })
 
 test_that("std model with 2 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g2 <- sngraph(2L, "std", 0)
   fit2 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -97,6 +107,7 @@ test_that("std model with 2 segments returned", {
 })
 
 test_that("std model with 3 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g3 <- sngraph(3L, "std", 0)
   fit3 <- gfpop::gfpop(
     profile614chr2$probes$logratio,

--- a/vignettes/applications.Rmd
+++ b/vignettes/applications.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 ```
 
 ```{r}
-library(devtools)
-devtools::install_github("vrunge/gfpop.data")
+## gfpop.data is available on GitHub (vrunge/gfpop.data). Install it once with
+## remotes::install_github("vrunge/gfpop.data") if you do not already have it.
 library(gfpop.data)
 library(gfpop)
 


### PR DESCRIPTION
Hi! This is the first of a few small PRs for the GSoC time-dependent constraints project. I am starting with CI so everything after it gets checked automatically.

## What this does

- Adds a standard r-lib `R-CMD-check` workflow on Ubuntu, macOS, and Windows (R release), running on push and pull request.
- Makes the test suite and vignettes run cleanly on CI. Right now `tests/testthat/test-sn.R` and `vignettes/applications.Rmd` call `devtools::install_github("vrunge/gfpop.data")` during `R CMD check`, which fails in a clean CI sandbox. I changed the test to use `skip_if_not_installed()` (with `gfpop.data` preinstalled in CI) and removed the build-time install from the vignette. Behavior is otherwise unchanged.
- Adds an `R-CMD-check` badge to the README and ignores `.github` in the package build.

## Result

`R CMD check` passes with `Status: OK` (0 errors, 0 warnings, 0 notes) on all three OSes.

## One thing to confirm

The `push` trigger currently runs on any branch, which is handy for getting a green check on a fork before opening a PR. If you would prefer it only run on `main`/`master` to save Actions minutes, I am glad to change that. The `pull_request` trigger is already scoped to `main`/`master`.

## Test plan

- [x] CI green on Ubuntu, macOS, Windows
- [x] Existing tests pass (the `sn` tests skip cleanly when `gfpop.data` is absent)
- [x] Vignettes build without network installs during the check