### PR TITLE
Add rule column to graph (R API for time-dependent constraints)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@ build.sh
 ^.*\.Rproj$
 ^\.Rproj\.user$
 .travis.yml
+^\.github$
 figure
 gfpop_1.1.1.pdf
 tex

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,6 @@ name: R-CMD-check
 
 on:
   push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,40 @@
+name: R-CMD-check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::rcmdcheck
+            github::vrunge/gfpop.data
+          needs: check
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
+            any::remotes
             github::vrunge/gfpop.data
           needs: check
       - uses: r-lib/actions/check-r-package@v2

--- a/R/graph.R
+++ b/R/graph.R
@@ -13,7 +13,8 @@
 #' @param penalty a nonnegative number. The penality associated to this state transition
 #' @param K a positive number. Threshold for the Biweight robust loss
 #' @param a a positive number. Slope for the Huber robust loss
-#' @return a one-row dataframe with 9 variables
+#' @param rule an integer (or \code{NA}) giving the rule identifier under which the edge is active for time-dependent constraints. Default \code{NA} means the edge is active for all rules (backward compatible).
+#' @return a one-row dataframe with 10 variables (the last being \code{rule})
 #' @examples
 #' Edge("Dw", "Up", "up", gap = 1, penalty = 10, K = 3)
 #'
@@ -22,7 +23,7 @@
 #' Edge(0, 0, "null", penalty = 0, K = 2, a = 1)
 #'
 #' Edge("Dw", "Dw", type = "null", decay = 0.997)
-Edge <- function(state1, state2, type = "null", decay = 1, gap = 0, penalty = 0, K = Inf, a = 0)
+Edge <- function(state1, state2, type = "null", decay = 1, gap = 0, penalty = 0, K = Inf, a = 0, rule = NA)
 {
   allowed.types <- c("null", "std", "up", "down", "abs")
   if(!type %in% allowed.types){stop('type must be one of: ', paste(allowed.types, collapse=", "))}
@@ -38,12 +39,13 @@ Edge <- function(state1, state2, type = "null", decay = 1, gap = 0, penalty = 0,
   if(any(penalty < 0, na.rm=TRUE)){stop('penalty must be nonnegative')}
   if(any(K <= 0, na.rm=TRUE)){stop('K must be positive')}
   if(any(a < 0, na.rm=TRUE)){stop('a must be nonnegative')}
+  if(any(rule < 1, na.rm=TRUE)){stop('rule must be a positive integer')}
 
   #fill parameter variable
 
   if(type == "null"){parameter <- decay}else{parameter <- gap}
 
-  data.frame(state1, state2, type, parameter, penalty, K, a, min=NA, max=NA, stringsAsFactors = FALSE)
+  data.frame(state1, state2, type, parameter, penalty, K, a, min=NA, max=NA, rule = as.integer(rule), stringsAsFactors = FALSE)
 
 }
 
@@ -55,7 +57,7 @@ Edge <- function(state1, state2, type = "null", decay = 1, gap = 0, penalty = 0,
 #' @description Defining the beginning and ending states of a graph
 #' @param start a vector of states. The beginning nodes for the changepoint inference
 #' @param end a vector of states. The ending nodes for the changepoint inference
-#' @return dataframe with 9 variables with only \code{state1} and \code{type = "start"} or \code{"end"} defined (not \code{NA}).
+#' @return dataframe with 10 variables with only \code{state1} and \code{type = "start"} or \code{"end"} defined (not \code{NA}).
 #' @examples
 #' StartEnd(start = "A", end = c("A","B"))
 #'
@@ -72,17 +74,17 @@ StartEnd <- function(start = NULL, end = NULL)
   start <- unique(start)
   end <- unique(end)
 
-  df <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), stringsAsFactors = FALSE)
-  colnames(df) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max")
+  df <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), integer(0), stringsAsFactors = FALSE)
+  colnames(df) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max", "rule")
   if(length(start) != 0)
   {
     for(i in 1:length(start))
-      {df[i,] <- list(start[i], NA, "start", NA, NA, NA, NA, NA, NA)}
+      {df[i,] <- list(start[i], NA, "start", NA, NA, NA, NA, NA, NA, NA)}
   }
   if(length(end) != 0)
   {
     for(i in 1:length(end))
-      {df[i + length(start),] <- list(end[i], NA, "end", NA, NA, NA, NA, NA, NA)}
+      {df[i + length(start),] <- list(end[i], NA, "end", NA, NA, NA, NA, NA, NA, NA)}
   }
   return(df)
 }
@@ -96,7 +98,7 @@ StartEnd <- function(start = NULL, end = NULL)
 #' @param state a string defining the state to constrain
 #' @param min minimal value for the inferred parameter
 #' @param max maximal value for the inferred parameter
-#' @return a dataframe with 9 variables with only \code{state1}, \code{min} and \code{max} defined (not \code{NA}).
+#' @return a dataframe with 10 variables with only \code{state1}, \code{min} and \code{max} defined (not \code{NA}).
 #' @examples
 #' Node(state = "s0", min = 0, max = 2)
 #'
@@ -111,9 +113,9 @@ Node <- function(state = NULL, min = -Inf, max = Inf)
   if(!is.double(max)){stop('max is not a double.')}
   if(min > max){stop('min is greater than max')}
 
-  df <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), stringsAsFactors = FALSE)
-  colnames(df) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max")
-  df [1,] <- data.frame(state, state, "node", NA, NA, NA, NA, min, max, stringsAsFactors = FALSE)
+  df <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), integer(0), stringsAsFactors = FALSE)
+  colnames(df) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max", "rule")
+  df [1,] <- data.frame(state, state, "node", NA, NA, NA, NA, min, max, NA, stringsAsFactors = FALSE)
   return(df)
 }
 
@@ -131,8 +133,8 @@ Node <- function(state = NULL, min = -Inf, max = Inf)
 #' @param K a positive number. Threshold for the Biweight robust loss
 #' @param a a positive number. Slope for the Huber robust loss
 #' @param all.null.edges a boolean. Add null edges to all nodes automatically
-#' @return a dataframe with 9 variables :
-#' columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"} with additional \code{"graph"} class.
+#' @return a dataframe with 10 variables :
+#' columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"}, \code{"rule"} with additional \code{"graph"} class.
 #' @examples
 #' graph(type = "updown", gap = 1.3, penalty = 5)
 #'
@@ -177,8 +179,8 @@ graph <- function(..., type = "empty", decay = 1, gap = 0, penalty = 0, K = Inf,
     if(!is.double(penalty)){stop('penalty is not a double.')}
     if(penalty < 0){stop('penalty must be nonnegative')}
 
-    myNewGraph <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), stringsAsFactors = FALSE)
-    names(myNewGraph) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max")
+    myNewGraph <- data.frame(character(), character(), character(), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), numeric(0), integer(0), stringsAsFactors = FALSE)
+    names(myNewGraph) <- c("state1", "state2", "type", "parameter", "penalty", "K", "a", "min", "max", "rule")
 
     if(type == "std")
     {

--- a/R/paperGraphs.R
+++ b/R/paperGraphs.R
@@ -11,8 +11,8 @@
 #' @param oneValue the value for parameter when we consider the collective anomalies problem
 #' @param K a positive number. Threshold for the Biweight robust loss
 #' @param a a positive number. Slope for the Huber robust loss
-#' @return a dataframe with 9 variables :
-#' columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"} with additional \code{"graph"} class.
+#' @return a dataframe with 10 variables :
+#' columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"}, \code{"rule"} with additional \code{"graph"} class.
 #'
 paperGraph <- function(nb, penalty = 0, decay = 1, gap = 0, oneValue = 0, K = Inf, a = 0)
 {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!--[![Build Status](http://travis-ci.com/vrunge/gfpop.svg?branch=master)](http://travis-ci.com/vrunge/gfpop)
 --> 
+[![R-CMD-check](https://github.com/vrunge/gfpop/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vrunge/gfpop/actions/workflows/R-CMD-check.yaml)
 [![](https://img.shields.io/badge/docs-vignettes-blue.svg)](https://github.com/vrunge/gfpop)
 
 <!-- 

--- a/man/Edge.Rd
+++ b/man/Edge.Rd
@@ -12,7 +12,8 @@ Edge(
   gap = 0,
   penalty = 0,
   K = Inf,
-  a = 0
+  a = 0,
+  rule = NA
 )
 }
 \arguments{
@@ -32,9 +33,11 @@ the transition to stay on the same segment.}
 \item{K}{a positive number. Threshold for the Biweight robust loss}
 
 \item{a}{a positive number. Slope for the Huber robust loss}
+
+\item{rule}{an integer (or \code{NA}) giving the rule identifier under which the edge is active for time-dependent constraints. Default \code{NA} means the edge is active for all rules (backward compatible).}
 }
 \value{
-a one-row dataframe with 9 variables
+a one-row dataframe with 10 variables (the last being \code{rule})
 }
 \description{
 Edge creation for gfpop-R-Package graph

--- a/man/Node.Rd
+++ b/man/Node.Rd
@@ -14,7 +14,7 @@ Node(state = NULL, min = -Inf, max = Inf)
 \item{max}{maximal value for the inferred parameter}
 }
 \value{
-a dataframe with 9 variables with only \code{state1}, \code{min} and \code{max} defined (not \code{NA}).
+a dataframe with 10 variables with only \code{state1}, \code{min} and \code{max} defined (not \code{NA}).
 }
 \description{
 Constrain the range of values to consider at a node

--- a/man/StartEnd.Rd
+++ b/man/StartEnd.Rd
@@ -12,7 +12,7 @@ StartEnd(start = NULL, end = NULL)
 \item{end}{a vector of states. The ending nodes for the changepoint inference}
 }
 \value{
-dataframe with 9 variables with only \code{state1} and \code{type = "start"} or \code{"end"} defined (not \code{NA}).
+dataframe with 10 variables with only \code{state1} and \code{type = "start"} or \code{"end"} defined (not \code{NA}).
 }
 \description{
 Defining the beginning and ending states of a graph

--- a/man/graph.Rd
+++ b/man/graph.Rd
@@ -33,8 +33,8 @@ graph(
 \item{all.null.edges}{a boolean. Add null edges to all nodes automatically}
 }
 \value{
-a dataframe with 9 variables :
-columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"} with additional \code{"graph"} class.
+a dataframe with 10 variables :
+columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"}, \code{"rule"} with additional \code{"graph"} class.
 }
 \description{
 Graph creation using component functions \code{Edge}, \code{StartEnd} and \code{Node}

--- a/man/paperGraph.Rd
+++ b/man/paperGraph.Rd
@@ -22,8 +22,8 @@ paperGraph(nb, penalty = 0, decay = 1, gap = 0, oneValue = 0, K = Inf, a = 0)
 \item{a}{a positive number. Slope for the Huber robust loss}
 }
 \value{
-a dataframe with 9 variables :
-columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"} with additional \code{"graph"} class.
+a dataframe with 10 variables :
+columns are named \code{"state1"}, \code{"state2"}, \code{"type"}, \code{"parameter"}, \code{"penalty"}, \code{"K"}, \code{"a"}, \code{"min"}, \code{"max"}, \code{"rule"} with additional \code{"graph"} class.
 }
 \description{
 Graphs of our paper in JSS (Journal of Statistical Software)

--- a/tests/testthat/test-rule.R
+++ b/tests/testthat/test-rule.R
@@ -1,0 +1,75 @@
+library(testthat)
+library(gfpop)
+context("rule")
+
+test_that("Edge has an integer rule column, NA by default", {
+  e <- Edge("a", "b", "std")
+  expect_true("rule" %in% names(e))
+  expect_identical(names(e)[length(names(e))], "rule")
+  expect_type(e$rule, "integer")
+  expect_true(is.na(e$rule))
+})
+
+test_that("Edge(rule=) sets the rule id", {
+  e <- Edge("a", "b", "std", rule = 2)
+  expect_identical(e$rule, 2L)
+})
+
+test_that("Edge is vectorized over rule", {
+  e <- Edge(c("a", "c"), c("b", "d"), "std", rule = 1)
+  expect_identical(e$rule, c(1L, 1L))
+})
+
+test_that("Edge rejects non-positive rule ids", {
+  expect_error(Edge("a", "b", "std", rule = 0), "rule must be a positive integer")
+  expect_error(Edge("a", "b", "std", rule = -1), "rule must be a positive integer")
+})
+
+test_that("StartEnd and Node carry a rule column matching Edge", {
+  se <- StartEnd("a", "a")
+  nd <- Node("a", 0, 1)
+  e <- Edge("a", "a", "std")
+  expect_identical(names(se), names(e))
+  expect_identical(names(nd), names(e))
+  expect_true(is.na(se$rule[1]))
+  expect_true(is.na(nd$rule[1]))
+})
+
+test_that("predefined graphs have an all-NA rule column", {
+  g <- graph(type = "updown", penalty = 5)
+  expect_true("rule" %in% names(g))
+  expect_true(all(is.na(g$rule)))
+})
+
+test_that("custom graph preserves per-edge rule values", {
+  g <- graph(
+    Edge("a", "a", "null", rule = 1),
+    Edge("a", "a", "std", penalty = 5, rule = 2))
+  expect_identical(g$rule, c(1L, 2L))
+})
+
+test_that("graphReorder preserves rule values with their edges", {
+  g <- graph(
+    Edge("a", "a", "null", rule = 1),
+    Edge("a", "a", "std", penalty = 5, rule = 2),
+    StartEnd("a", "a"))
+  reordered <- gfpop:::graphReorder(g)$graph
+  expect_true("rule" %in% names(reordered))
+  expect_identical(reordered$rule[reordered$type == "null"], 1L)
+  expect_identical(reordered$rule[reordered$type == "std"], 2L)
+})
+
+test_that("gfpop still solves a standard problem with the rule column present", {
+  set.seed(42)
+  x <- c(rnorm(40, 0), rnorm(40, 10))
+  g <- graph(type = "std", penalty = 2 * log(80))
+  fit <- gfpop(x, g, type = "mean")
+  expect_s3_class(fit, "gfpop")
+  ## last changepoint is the data length
+  expect_identical(fit$changepoints[length(fit$changepoints)], 80L)
+  ## one internal change near the true location (index 40)
+  internal <- fit$changepoints[-length(fit$changepoints)]
+  expect_true(any(internal >= 35 & internal <= 45))
+  ## parameters and changepoints are aligned in length
+  expect_identical(length(fit$parameters), length(fit$changepoints))
+})

--- a/tests/testthat/test-sn.R
+++ b/tests/testthat/test-sn.R
@@ -1,17 +1,22 @@
 library(gfpop)
-library(devtools)
-devtools::install_github("vrunge/gfpop.data")
-library(gfpop.data)
-
 library(testthat)
 context("sn")
 
-library(data.table)
+## The sn tests rely on the gfpop.data package (GitHub only:
+## vrunge/gfpop.data) and data.table. Skip gracefully when unavailable
+## instead of installing packages at test time.
+have.sn.deps <- requireNamespace("gfpop.data", quietly = TRUE) &&
+  requireNamespace("data.table", quietly = TRUE)
 
-data(profile614chr2, package="gfpop.data")
+if (have.sn.deps) {
+  library(gfpop.data)
+  library(data.table)
 
-### reduce data size
-profile614chr2$probes <- profile614chr2$probes[1:10000,]
+  data(profile614chr2, package = "gfpop.data")
+
+  ### reduce data size
+  profile614chr2$probes <- profile614chr2$probes[1:10000, ]
+}
 
 g <- gfpop::graph(type="std")
 x <- rnorm(10)
@@ -40,6 +45,7 @@ sngraph <- function(n.segs, type, gap)
 ######
 
 test_that("abs model with 1 segment returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g1 <- sngraph(1L, "abs", 1)
   fit1 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -50,6 +56,7 @@ test_that("abs model with 1 segment returned", {
 })
 
 test_that("abs model with 2 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g2 <- sngraph(2L, "abs", 1)
   fit2 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -61,6 +68,7 @@ test_that("abs model with 2 segments returned", {
 })
 
 test_that("abs model with 3 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g3 <- sngraph(3L, "abs", 1)
   fit3 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -76,6 +84,7 @@ test_that("abs model with 3 segments returned", {
 ######
 
 test_that("std model with 1 segment returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g1 <- sngraph(1L, "std", 0)
   fit1 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -86,6 +95,7 @@ test_that("std model with 1 segment returned", {
 })
 
 test_that("std model with 2 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g2 <- sngraph(2L, "std", 0)
   fit2 <- gfpop::gfpop(
     profile614chr2$probes$logratio,
@@ -97,6 +107,7 @@ test_that("std model with 2 segments returned", {
 })
 
 test_that("std model with 3 segments returned", {
+  skip_if_not(have.sn.deps, "gfpop.data/data.table not installed")
   g3 <- sngraph(3L, "std", 0)
   fit3 <- gfpop::gfpop(
     profile614chr2$probes$logratio,

--- a/vignettes/applications.Rmd
+++ b/vignettes/applications.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 ```
 
 ```{r}
-library(devtools)
-devtools::install_github("vrunge/gfpop.data")
+## gfpop.data is available on GitHub (vrunge/gfpop.data). Install it once with
+## remotes::install_github("vrunge/gfpop.data") if you do not already have it.
 library(gfpop.data)
 library(gfpop)
 


### PR DESCRIPTION
Second small PR for the GSoC time-dependent constraints project. This adds the R side of the new `rule` API. I would love your feedback on the API shape before I build the solver side on top of it, so I am opening it as a draft.

Note on stacking: this branch sits on top of #20 (the CI PR). Until #20 is merged, the diff here also includes the CI commits. The actual change in this PR is the commit "feat: add rule column to graph for time-dependent constraints". Once #20 merges, this diff will show only the rule-column changes.

## What this does

- Adds an optional integer `rule` column to `Edge()`, `graph()`, `StartEnd()`, and `Node()`, carried through `graphReorder()`.
- Default is `rule = NA`, meaning the edge is active under every rule. If no rule is used anywhere, graphs and `gfpop()` results are unchanged.
- The column has no effect on the solver yet. It is just the API surface that a later PR wires into the C++ dynamic program.

## API question

The idea: each edge can carry a `rule` id, and (in a later PR) `gfpop(..., rule = <per-point integer vector>)` selects which edges are active at each data point. Does this shape look right to you, or would you prefer the rule to live elsewhere (for example on the data side, or as a separate mapping)?

## Backward compatibility

- Existing code is unaffected (`rule` defaults to NA).
- Adds tests in `tests/testthat/test-rule.R`; existing suite unchanged.

## Test plan

- [x] New rule-column tests pass
- [x] Existing tests pass
- [x] gfpop() output identical with and without a rule column